### PR TITLE
Fix typos and function names in documentation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: vertesy/ggExpress - the fastest way to create, annotate and and save plots in R.
+title: vertesy/ggExpress - the fastest way to create, annotate and save plots in R.
 version: v0.9.5
 message: >-
   If you use this software, please cite it using these metadata.

--- a/Development/Development.bac
+++ b/Development/Development.bac
@@ -451,7 +451,7 @@ qbarplot.df <- function(
 #' @param NamedSlices NamedSlices
 #' @param extended.canvas Make an extended canvas, default: T
 #' @param custom.margin custom plot margin, default: T
-#' @param max.categories Maximum number of categories to be shown as a seprate slice
+#' @param max.categories Maximum number of categories to be shown as a separate slice
 #' @param decr.order Slices in the order of df. By default would ordered alphabetically in the plot.
 #' @param both_pc_and_value Report both percentage AND number.
 #' @param custom.order custom.order
@@ -1252,7 +1252,7 @@ qqqAxisLength <- function(vec = 1:20, minLength = 6, factor = 0.4) {
 # _________________________________________________________________________________________________
 #' @title qqqNamed.Vec.2.Tbl
 #'
-#' @description Covert a named vector to a table.
+#' @description Convert a named vector to a table.
 #' @param namedVec namedVec
 #' @param verbose verbose
 #' @param strip.too.many.names strip.too.many.names
@@ -1288,7 +1288,7 @@ qqqNamed.Vec.2.Tbl <- function(namedVec = 1:14, verbose = FALSE, strip.too.many.
 # _________________________________________________________________________________________________
 #' @title qqqTbl.2.Vec
 #'
-#' @description Covert a table to a named vector.
+#' @description Convert a table to a named vector.
 #' @param tibble.input tibble.input
 #' @param name.column name.column
 #' @param value.column value.column
@@ -1309,7 +1309,7 @@ qqqTbl.2.Vec <- function(tibble.input, name.column = 1, value.column = 2) { # Co
 # _________________________________________________________________________________________________
 #' @title qqqList.2.DF.ggplot
 #'
-#' @description Convert a list to a tow-column data frame to plot boxplots and violin plots
+#' @description Convert a list to a two-column data frame to plot boxplots and violin plots
 #' @param ls A list with all elements named
 #' @importFrom CodeAndRoll2 is.list2
 #' @examples LetterSets <- list("One" = LETTERS[1:7], "Two" = LETTERS[3:12])

--- a/Development/ggExpress.auxiliary.functions.R
+++ b/Development/ggExpress.auxiliary.functions.R
@@ -98,17 +98,17 @@ qqqAxisLength <- function(vec = 1:20, minLength=6) {
 
 
 # ------------------------------------------------------------------------------------------------
-#' @title qqqCovert.named.vec2tbl
-#' @description Covert a named vector to a table.
+#' @title qqqConvert.named.vec2tbl
+#' @description Convert a named vector to a table.
 #' @param namedVec namedVec
 #' @param verbose verbose
 #' @param strip.too.many.names strip.too.many.names
 #' @param thr thr
 #' @export
 #'
-#' @examples qqqCovert.named.vec2tbl(namedVec = c("A"=2, "B"=29) )
+#' @examples qqqConvert.named.vec2tbl(namedVec = c("A"=2, "B"=29) )
 
-qqqCovert.named.vec2tbl <- function(namedVec=1:14, verbose = F, strip.too.many.names = TRUE, thr = 50) { # Convert a named vector to a 2 column tibble (data frame) with 2 columns: value, name.
+qqqConvert.named.vec2tbl <- function(namedVec=1:14, verbose = F, strip.too.many.names = TRUE, thr = 50) { # Convert a named vector to a 2 column tibble (data frame) with 2 columns: value, name.
 
   # Check naming issues
   nr.uniq.names <- length(unique(names(namedVec)))
@@ -128,16 +128,16 @@ qqqCovert.named.vec2tbl <- function(namedVec=1:14, verbose = F, strip.too.many.n
 
 
 # ------------------------------------------------------------------------------------------------
-#' @title qqqCovert.tbl2vec
-#' @description Covert a table to a named vector.
+#' @title qqqConvert.tbl2vec
+#' @description Convert a table to a named vector.
 #' @param tibble.input tibble.input
 #' @param name.column name.column
 #' @param value.column value.column
 #' @export
 #'
-#' @examples a=1:5; x= tibble::tibble(a, a * 2); qqqCovert.tbl2vec(x)
+#' @examples a=1:5; x= tibble::tibble(a, a * 2); qqqConvert.tbl2vec(x)
 
-qqqCovert.tbl2vec <- function(tibble.input, name.column = 1, value.column = 2) { # Convert a named vector to a 2 column tibble (data frame) with 2 columns: value, name.
+qqqConvert.tbl2vec <- function(tibble.input, name.column = 1, value.column = 2) { # Convert a named vector to a 2 column tibble (data frame) with 2 columns: value, name.
   vec <- tibble.input[[value.column]]
   names(vec) <- tibble.input[[name.column]]
   vec

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ devtools::install_github(repo = "vertesy/ReadWriter", upgrade = F)
 devtools::install_github(repo = "vertesy/CodeAndRoll2", upgrade = F)
 devtools::install_github(repo = "vertesy/MarkdownHelpers", upgrade = F)
 
-# Install MarkdownHelpers
+# Install ggExpress
 devtools::install_github(repo = "vertesy/ggExpress")
 ```
 
@@ -117,7 +117,7 @@ qviolin. Draw and save a violin plot
 - #### 10 `qstripchart()`
 qstripchart. Generates a stripchart and saves the plot for a given 2-column dataframe and offers several customizations.
 
-- #### 11 `# qheatmap()`
+- #### 11 `qvenn()`
 qvenn - Venn Diagram. Draw and save a Venn Diagram using the `ggVennDiagram` package.
 
 - #### 12 `qqSave()`
@@ -136,11 +136,11 @@ qMarkdownImageLink. Insert Markdown image link to .md report
 qqqAxisLength. Define Axis Length
 
 - #### 17 `qqqNamed.Vec.2.Tbl()`
-qqqNamed.Vec.2.Tbl. Covert a named vector to a table.
+qqqNamed.Vec.2.Tbl. Convert a named vector to a table.
 
 - #### 18 `qqqTbl.2.Vec()`
-qqqTbl.2.Vec. Covert a table to a named vector.
+qqqTbl.2.Vec. Convert a table to a named vector.
 
 - #### 19 `qqqList.2.DF.ggplot()`
-qqqList.2.DF.ggplot. Convert a list to a tow-column data frame to plot boxplots and violin plots
+qqqList.2.DF.ggplot. Convert a list to a two-column data frame to plot boxplots and violin plots
 

--- a/man/qpie.Rd
+++ b/man/qpie.Rd
@@ -81,7 +81,7 @@ qpie(
 
 \item{custom.margin}{custom plot margin, default: T}
 
-\item{max.categories}{Maximum number of categories to be shown as a seprate slice}
+\item{max.categories}{Maximum number of categories to be shown as a separate slice}
 
 \item{max.names}{The maximum number of names still to be shown on the axis.}
 

--- a/man/qqqList.2.DF.ggplot.Rd
+++ b/man/qqqList.2.DF.ggplot.Rd
@@ -10,7 +10,7 @@ qqqList.2.DF.ggplot(ls = LetterSets)
 \item{ls}{A list with all elements named}
 }
 \description{
-Convert a list to a tow-column data frame to plot boxplots and violin plots
+Convert a list to a two-column data frame to plot boxplots and violin plots
 }
 \examples{
 LetterSets <- list("One" = LETTERS[1:7], "Two" = LETTERS[3:12])

--- a/man/qqqNamed.Vec.2.Tbl.Rd
+++ b/man/qqqNamed.Vec.2.Tbl.Rd
@@ -21,7 +21,7 @@ qqqNamed.Vec.2.Tbl(
 \item{thr}{thr}
 }
 \description{
-Covert a named vector to a table.
+Convert a named vector to a table.
 }
 \examples{
 qqqNamed.Vec.2.Tbl(namedVec = c("A" = 2, "B" = 29))

--- a/man/qqqTbl.2.Vec.Rd
+++ b/man/qqqTbl.2.Vec.Rd
@@ -14,7 +14,7 @@ qqqTbl.2.Vec(tibble.input, name.column = 1, value.column = 2)
 \item{value.column}{value.column}
 }
 \description{
-Covert a table to a named vector.
+Convert a table to a named vector.
 }
 \examples{
 a <- 1:5


### PR DESCRIPTION
## Summary
- Correct duplicated wording in CITATION title
- Repair README installation line and function list typos
- Fix manual page spelling and rename helper functions in development scripts

## Testing
- `R CMD check --no-manual` *(fails: command not found: R)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689339fd5ec8832c831c4d06a9167a6b