### PR TITLE
Fix spelling mistakes across codebase

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: ggExpress is a set of R functions that allows you to generate
     you just discovered with your analysis script. It is ggplot-based
     smaller brother of vertesy/MarkdownReports. It helps you to: 1. Create
     scientifically accurate (annotated) figures with very short code,
-    making use of variable-, row- and columnnames.  2. Save figures
+    making use of variable-, row- and column names.  2. Save figures
     automatically as vector graphic (.pdf), that you can use from
     presentation to posters anywhere.  3. Incorporate your figures
     automatically in a markdown report file.  4. Describe your figures &

--- a/Development/Create_the_ggExpress_Package.OLD.R
+++ b/Development/Create_the_ggExpress_Package.OLD.R
@@ -34,7 +34,7 @@ DESCRIPTION <- list("Title" = "ggExpress is the fastest way to create, annotate 
     , "Authors@R" = 'person(given = "Abel", family = "Vertesy", email = "a.vertesy@imba.oeaw.ac.at", role =  c("aut", "cre") )'
     , "Description" = "ggExpress is a set of R functions that allows you to generate precise figures easily,
     and create clean markdown reports about what you just discovered with your analysis script. It is ggplot-based smaller brother of vertesy/MarkdownReports. It helps you to:
-    1. Create scientifically accurate (annotated) figures with very short code, making use of variable-, row- and columnnames.
+    1. Create scientifically accurate (annotated) figures with very short code, making use of variable-, row- and column names.
     2. Save figures automatically as vector graphic (.pdf), that you can use from presentation to posters anywhere.
     3. Incorporate your figures automatically in a markdown report file.
     4. Describe your figures & findings in the same report in a clear and nicely formatted way, parsed from your variables into english sentences.

--- a/Development/Development.bac
+++ b/Development/Development.bac
@@ -574,7 +574,7 @@ qpie <- function(
 #' @title qboxplot
 #'
 #' @description Draw and save a boxplot
-#' @param df_XYcol_or_list Data, as 2 column data frame, where col.1 is X axis, alternatively a uniquely named list ov values.
+#' @param df_XYcol_or_list Data, as 2 column data frame, where col.1 is X axis, alternatively a uniquely named list of values.
 #' @param plotname The title of the plot and the name of the file (unless specified in `filename`).
 #' @param subtitle Optional subtitle text added below the title. Default is NULL.
 #' @param caption Optional text added to bottom right corner of the plot. Default = suffix
@@ -673,7 +673,7 @@ qboxplot <- function(
 #' @title qviolin
 #'
 #' @description Draw and save a violin plot
-#' @param df_XYcol_or_list Data, as 2 column data frame, where col.1 is X axis, alternatively a uniquely named list ov values.
+#' @param df_XYcol_or_list Data, as 2 column data frame, where col.1 is X axis, alternatively a uniquely named list of values.
 #' @param plotname Name of the plot
 #' @param subtitle Optional subtitle text added below the title. Default is NULL.
 #' @param suffix Optional suffix added to the filename. Default is NULL.
@@ -776,7 +776,7 @@ qviolin <- function(
 #' @title qstripchart
 #'
 #' @description Generates a stripchart and saves the plot for a given 2-column dataframe and offers several customizations.
-#' @param df_XYcol_or_list Data, as 2 column data frame, where col.1 is X axis, alternatively a uniquely named list ov values.
+#' @param df_XYcol_or_list Data, as 2 column data frame, where col.1 is X axis, alternatively a uniquely named list of values.
 #' @param plotname Name of the plot
 #' @param subtitle Optional subtitle text added below the title. Default is NULL.
 #' @param suffix Optional suffix added to the filename. Default is NULL.

--- a/Development/config.R
+++ b/Development/config.R
@@ -7,7 +7,7 @@ DESCRIPTION <- list(
   title = "ggExpress is the fastest way to create, annotate and export plots in R",
   description = "ggExpress is a set of R functions that allows you to generate precise figures easily,
     and create clean markdown reports about what you just discovered with your analysis script. It is ggplot-based smaller brother of vertesy/MarkdownReports. It helps you to:
-    1. Create scientifically accurate (annotated) figures with very short code, making use of variable-, row- and columnnames.
+    1. Create scientifically accurate (annotated) figures with very short code, making use of variable-, row- and column names.
     2. Save figures automatically as vector graphic (.pdf), that you can use from presentation to posters anywhere.
     3. Incorporate your figures automatically in a markdown report file.
     4. Describe your figures & findings in the same report in a clear and nicely formatted way, parsed from your variables into english sentences.

--- a/Examples/Testing.ggpubr.R
+++ b/Examples/Testing.ggpubr.R
@@ -96,7 +96,7 @@ data("mtcars")
 dfm <- mtcars
 # Convert the cyl variable to a factor
 dfm$cyl <- as.factor(dfm$cyl)
-# Add the name colums
+# Add the name columns
 dfm$name <- rownames(dfm)
 # Inspect the data
 head(dfm[, c("name", "wt", "mpg", "cyl")])
@@ -106,8 +106,8 @@ head(dfm[, c("name", "wt", "mpg", "cyl")])
 p<- ggbarplot(dfm, x = "name", y = "mpg",
               fill = "cyl",               # change fill color by cyl
               color = "white",            # Set bar border colors to white
-              palette = "jco",            # jco journal color palett. see ?ggpar
-              sort.val = "desc",          # Sort the value in dscending order
+              palette = "jco",            # jco journal color palette. see ?ggpar
+              sort.val = "desc",          # Sort the value in descending order
               sort.by.groups = FALSE,     # Don't sort inside each group
               x.text.angle = 90           # Rotate vertically x axis texts
 )+ grids(axis ='y')

--- a/R/ggExpress.R
+++ b/R/ggExpress.R
@@ -1832,7 +1832,7 @@ qqqTbl.2.Vec <- function(tibble.input, name.column = 1, value.column = 2) { # Co
 # _________________________________________________________________________________________________
 #' @title qqqList.2.DF.ggplot
 #'
-#' @description Convert a list to a tow-column data frame to plot boxplots and violin plots
+#' @description Convert a list to a two-column data frame to plot boxplots and violin plots
 #' @param ls A list with all elements named
 #' @importFrom CodeAndRoll2 is.list2
 #' @examples LetterSets <- list("One" = LETTERS[1:7], "Two" = LETTERS[3:12])


### PR DESCRIPTION
## Summary
- fix typo in qqqList.2.DF.ggplot documentation
- correct column-related spelling in examples and package metadata
- replace incorrect phrases in development scripts

## Testing
- `R -q -e "devtools::document(); devtools::check()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68948b688cb8832cba9e1b4d24661c54