### PR TITLE
Add concise input validation

### DIFF
--- a/R/ggExpress.R
+++ b/R/ggExpress.R
@@ -78,6 +78,7 @@ qhistogram <- function(
     max.names = 50,
     grid = "y",
     w = 5, h = w, ...) {
+  stopifnot(is.numeric(vec), length(vec) > 0L, all(is.finite(vec)))
   if (isFALSE(xlab)) xlab <- plotname
   df <- qqqNamed.Vec.2.Tbl(namedVec = vec, thr = max.names)
 
@@ -176,6 +177,7 @@ qdensity <- function(
     max.names = 50,
     grid = FALSE,
     w = 5, h = w, ...) {
+  stopifnot(is.numeric(vec), length(vec) > 0L, all(is.finite(vec)))
   if (isFALSE(xlab)) xlab <- plotname
   df <- qqqNamed.Vec.2.Tbl(namedVec = vec, thr = max.names)
 
@@ -276,6 +278,7 @@ qpie <- function(
     labels = "names", # Set to NULL to remove slice names.
     w = 7, h = 5,
     ...) {
+  stopifnot(is.numeric(vec), length(vec) > 0L, all(is.finite(vec)), all(vec >= 0))
   print(plotname)
   l.orig <- length(vec)
   sum.orig <- sum(vec)
@@ -430,7 +433,7 @@ qbarplot <- function(
     ylab = NULL,
     w = qqqAxisLength(vec, factor = 0.25), h = 5,
     ...) {
-  stopifnot(is.numeric(vec))
+  stopifnot(is.numeric(vec), length(vec) > 0L, all(is.finite(vec)))
   if (isFALSE(xlab)) xlab <- plotname
   df <- qqqNamed.Vec.2.Tbl(namedVec = vec, strip.too.many.names = FALSE)
 
@@ -710,8 +713,14 @@ qbarplot.df <- function(
     w = qqqAxisLength(df), h = 5,
     ...) {
   message(plotname)
-  stopifnot(is.data.frame(df), ncol(df) > 2,
-    "Y axis must be numeric" = is.numeric(y)
+  cols <- colnames(df)
+  x <- if (is.numeric(x)) cols[x] else x
+  y <- if (is.numeric(y)) cols[y] else y
+  fill <- if (is.numeric(fill)) cols[fill] else fill
+  stopifnot(
+    is.data.frame(df), ncol(df) > 2,
+    all(c(x, y, fill) %in% cols),
+    is.numeric(df[[y]])
   )
 
   if (is.null(xlab)) xlab <- if (scale) paste("%", x) else x
@@ -843,22 +852,22 @@ qscatter <- function(
   #
   print(plotname)
   stopifnot(
-    ncol(df_XYcol) >= 2,
-    is.numeric(x) | is.character(x),
-    is.numeric(y) | is.character(y)
+    is.data.frame(df_XYcol) || is.matrix(df_XYcol),
+    ncol(df_XYcol) >= 2L,
+    (is.numeric(x) && x <= ncol(df_XYcol)) || (is.character(x) && x %in% colnames(df_XYcol)),
+    (is.numeric(y) && y <= ncol(df_XYcol)) || (is.character(y) && y %in% colnames(df_XYcol))
   )
 
   if (is.matrix(df_XYcol)) df_XYcol <- as.data.frame(df_XYcol)
-
-  if (!is.numeric(x)) {
-    stopifnot(x %in% colnames(df_XYcol))
-    x <- which(colnames(df_XYcol) == x)
-  }
-
-  if (!is.numeric(y)) {
-    stopifnot(y %in% colnames(df_XYcol))
-    y <- which(colnames(df_XYcol) == y)
-  }
+  if (is.character(x)) x <- which(colnames(df_XYcol) == x)
+  if (is.character(y)) y <- which(colnames(df_XYcol) == y)
+  xv <- df_XYcol[[x]]
+  yv <- df_XYcol[[y]]
+  stopifnot(
+    is.numeric(xv), is.numeric(yv),
+    length(xv) > 0L, length(yv) > 0L,
+    all(is.finite(xv)), all(is.finite(yv))
+  )
 
   vars <- colnames(df_XYcol)
   names(vars) <- vars
@@ -1027,7 +1036,11 @@ qboxplot <- function(
   .assertMaxCategories(df_XYcol, col = x, max.categ)
   vars <- colnames(df_XYcol)
   names(vars) <- vars
-
+  stopifnot(
+    if (is.numeric(x)) x <= length(vars) else x %in% vars,
+    if (is.numeric(y)) y <= length(vars) else y %in% vars,
+    is.numeric(df_XYcol[[vars[y]]])
+  )
 
   palette_use_bac <- palette_use
   if (length(fill) > 1) {
@@ -1166,6 +1179,11 @@ qviolin <- function(
   # Define fill color
   vars <- colnames(df_XYcol)
   names(vars) <- vars
+  stopifnot(
+    if (is.numeric(x)) x <= length(vars) else x %in% vars,
+    if (is.numeric(y)) y <= length(vars) else y %in% vars,
+    is.numeric(df_XYcol[[vars[y]]])
+  )
   if (!is.null(col)) {
     if (is.numeric(col) & col < length(vars)) col <- col
     if (col %in% vars) col <- vars[col]
@@ -1297,6 +1315,11 @@ qstripchart <- function(
   # Define fill color
   vars <- colnames(df_XYcol)
   names(vars) <- vars
+  stopifnot(
+    if (is.numeric(x)) x <= length(vars) else x %in% vars,
+    if (is.numeric(y)) y <= length(vars) else y %in% vars,
+    is.numeric(df_XYcol[[vars[y]]])
+  )
   if (!is.null(col)) {
     if (is.numeric(col) & col < length(vars)) col <- col
     if (col %in% vars) col <- vars[col]
@@ -1391,6 +1414,7 @@ qvenn <- function(
     x_exp = .2,
     w = 8, h = 0.75 * w,
     ...) {
+  stopifnot(is.list(list), length(list) > 0L)
   #
   if (!is.null(caption2)) caption <- paste0(caption2, "\n", caption, "\n")
 


### PR DESCRIPTION
## Summary
- enforce numeric, finite vectors in qhistogram, qdensity, qpie, and qbarplot
- qbarplot.df normalizes column arguments, checks column presence, and requires numeric y data
- qboxplot, qviolin, and qstripchart validate selected columns and numeric y values
- qpie requires non-negative values before plotting and qscatter ensures selected columns exist and contain numeric, finite data
- qvenn requires a list input

## Testing
- `R -q -e "devtools::document(); devtools::check()"` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden for Ubuntu repositories)*
- `apt-get install -y r-base` *(fails: Unable to locate package r-base)*

------
https://chatgpt.com/codex/tasks/task_e_68948b4d9e38832cb105d3ad964b4492