### PR TITLE
Fix qvenn Venn diagram invocation

### DIFF
--- a/R/ggExpress.R
+++ b/R/ggExpress.R
@@ -1443,7 +1443,7 @@ qvenn <- function(
   #
   if (!is.null(caption2)) caption <- paste0(caption2, "\n", caption, "\n")
 
-  p <- ggVennDiagram::ggVennDiagram(list, ..., ) +
+  p <- ggVennDiagram::ggVennDiagram(list, ...) +
     ggplot2::scale_fill_gradient(low = col.min, high = col.max) +
     ggplot2::labs(
       title = paste(" ", plotname),


### PR DESCRIPTION
## Summary
- remove the trailing comma in `qvenn`'s `ggVennDiagram` call so the helper executes without an argument error

## Testing
- not run (R not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eedc41af883239768bb8e2de00327)