### PR TITLE
Simplify histogram colour assignment

### DIFF
--- a/R/ggExpress.R
+++ b/R/ggExpress.R
@@ -82,12 +82,16 @@ qhistogram <- function(
   if (isFALSE(xlab)) xlab <- plotname
   df <- qqqNamed.Vec.2.Tbl(namedVec = vec, thr = max.names)
 
-  df[["colour"]] <- if (!isFALSE(vline) & filtercol != 0) {
-    if (filtercol == 1) (df$"value" > vline) else if (filtercol == -1) (df$"value" < vline)
-  } else if (length(col) == length(vec)) {
-    as.character(col)
+  df[["colour"]] <- if (!isFALSE(vline) && filtercol != 0) {
+    if (filtercol == 1) {
+      df$"value" > vline
+    } else if (filtercol == -1) {
+      df$"value" < vline
+    } else {
+      rep_len(as.character(col), length(vec))
+    }
   } else {
-    as.character(rep(col, length(vec))[1:length(vec)])
+    rep_len(as.character(col), length(vec))
   }
 
   p <- ggpubr::gghistogram(


### PR DESCRIPTION
## Summary
- streamline qhistogram colour handling with a single rep_len-based branch
- keep custom colouring when vline filters are applied without changing other behaviour

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0e6250c8832393ecb2abbcf2271b)